### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ elixir:
 otp_release:
   - 17.4
 services: mysql
-before_script:
-  - export PATH=`pwd`/elixir/bin:$PATH
-  - mix local.hex --force
-  - mix deps.get
 script:
   - MIX_ENV=mysql mix test
   - MIX_ENV=pg mix test


### PR DESCRIPTION
Don't need the `before_script` in your `.travis.yml` anymore. Simplifying.
