### PR TITLE
Fix call to add/1 in ecto_auto_migration_index.

### DIFF
--- a/lib/ecto/migration/system_table.ex
+++ b/lib/ecto/migration/system_table.ex
@@ -5,7 +5,7 @@ defmodule Ecto.Migration.SystemTable.Index.Migration do
       add :tablename, :string
       add :index, :string
       add :name, :string
-      add :concurrently
+      add :concurrently, :boolean
       add :unique, :boolean
       add :using, :string
     end


### PR DESCRIPTION
Add "boolean" type to "concurrently" field.

It fixes the following build error on ecto 1.0.x:

```
== Compilation error on file lib/ecto/migration/system_table.ex ==
** (CompileError) lib/ecto/migration/system_table.ex:8: function add/1 undefined
    (stdlib) lists.erl:1337: :lists.foreach/2
    (stdlib) erl_eval.erl:669: :erl_eval.do_apply/6
    (stdlib) erl_eval.erl:122: :erl_eval.exprs/5
```
