### PR TITLE
Loosen dependency on Ecto

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -49,7 +49,7 @@ defmodule EctoMigrate.Mixfile do
   defp deps do
     [{:postgrex, ">= 0.0.0", optional: true},
      {:mariaex, ">= 0.0.0", optional: true},
-     {:ecto, "~> 1.0.0"},
+     {:ecto, "~> 1.0"},
      {:ecto_it, "~> 0.2.0", optional: true}]
   end
 end


### PR DESCRIPTION
Seems to work fine on Ecto 1.1.x (by adding `{ :ecto, "~> 1.1.3", override: true }` to an application's `mix.exs`).  Would seem reasonable to allow any Ecto 1.x until/unless an incompatibility is found.
